### PR TITLE
Two unrelated fixes...

### DIFF
--- a/src/Concerns/Respondable.php
+++ b/src/Concerns/Respondable.php
@@ -7,8 +7,8 @@ use Signifly\Responder\Contracts\Responder;
 
 trait Respondable
 {
-    protected function respond($data): Responsable
+    protected function respond($data, ?string $resourceClass = null): Responsable
     {
-        return app(Responder::class)->respond($data);
+        return app(Responder::class)->respond($data, $resourceClass);
     }
 }

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -96,9 +96,9 @@ class Responder implements Contract
      */
     protected function respondForPaginator(LengthAwarePaginator $data, ?string $resourceClass)
     {
-        $modelClass = $this->modelResolver->resolve($data, 'paginator');
-
         if (is_null($resourceClass)) {
+            $modelClass = $this->modelResolver->resolve($data, 'paginator');
+
             $resourceClass = empty($modelClass)
                 ? config('responder.default_resource', JsonResource::class)
                 : $this->resourceResolver->resolve($modelClass);

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -62,9 +62,9 @@ class Responder implements Contract
      */
     protected function respondForCollection(Collection $data, ?string $resourceClass)
     {
-        $modelClass = $this->modelResolver->resolve($data, 'collection');
-
         if (is_null($resourceClass)) {
+            $modelClass = $this->modelResolver->resolve($data, 'collection');
+
             $resourceClass = empty($modelClass)
                 ? config('responder.default_resource', JsonResource::class)
                 : $this->resourceResolver->resolve($modelClass);


### PR DESCRIPTION
Two changes in this PR (sorry):
* Allow `Respondable::respond()` to take/pass a resource class
* Resolve model class only if needed for collection and length aware paginator

The second change (resolving model class) was made for two reasons:
* it isn't necessary if a resource class is provided
* some resources aren't model-based, in which case the model resolution throws